### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-sync.yml
+++ b/.github/workflows/auto-sync.yml
@@ -10,6 +10,8 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/laurence77/Laurence-Photo-Hub/security/code-scanning/1](https://github.com/laurence77/Laurence-Photo-Hub/security/code-scanning/1)

The problem should be fixed by adding an explicit `permissions` block specifying the minimum required permissions for this workflow. This can be done either at the workflow root (above `jobs:`) or at the job level (inside the `sync:` job). Since only the `sync` job exists, doing it at the root is simplest and safest. Since the workflow commits and pushes changes, it requires `contents: write`. No other permissions are evidently needed, so we can specify:

```yaml
permissions:
  contents: write
```

This should be inserted between the `on:` block and the `jobs:` block (i.e., after line 12), or could go above the `jobs:` line. No changes are needed elsewhere in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
